### PR TITLE
Fix an error message when there is no large image fileId.

### DIFF
--- a/server/rest.py
+++ b/server/rest.py
@@ -34,6 +34,7 @@ class TilesItemResource(Item):
         self.resourceName = 'item'
         apiRoot.item.route('GET', (':itemId', 'tiles'), self.getTilesInfo)
         apiRoot.item.route('POST', (':itemId', 'tiles'), self.createTiles)
+        apiRoot.item.route('DELETE', (':itemId', 'tiles'), self.deleteTiles)
         apiRoot.item.route('GET', (':itemId', 'tiles', 'zxy', ':z', ':x', ':y'),
                            self.getTile)
 
@@ -57,7 +58,7 @@ class TilesItemResource(Item):
 
     getTilesInfo.description = (
         Description('Get multiresolution tiles metadata.')
-        .param('itemId', 'The ID of the item, or "test".', paramType='path')
+        .param('itemId', 'The ID of the item or "test".', paramType='path')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
@@ -68,7 +69,7 @@ class TilesItemResource(Item):
         largeImageFileId = params.get('fileId')
         if not largeImageFileId:
             raise RestException('Missing "fileId" parameter.')
-        if largeImageFileId not in ('test', 'clear'):
+        if largeImageFileId != 'test':
             largeImageFile = self.model('file').load(largeImageFileId,
                                                      force=True, exc=True)
             if largeImageFile['itemId'] != item['_id']:
@@ -89,8 +90,27 @@ class TilesItemResource(Item):
 
     createTiles.description = (
         Description('Create a multiresolution image for this item.')
-        .param('itemId', 'The ID of the item..', paramType='path')
-        .param('fileId', 'The ID of the source file containing the image.')
+        .param('itemId', 'The ID of the item.', paramType='path')
+        .param('fileId', 'The ID of the source file containing the image or '
+               '"test".')
+    )
+
+    @access.user
+    @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
+    def deleteTiles(self, item, params):
+        deleted = False
+        if 'largeImage' in item:
+            del item['largeImage']
+            self.model('item').save(item)
+            deleted = True
+        # TODO: a better response
+        return {
+            'deleted': deleted
+        }
+
+    deleteTiles.description = (
+        Description('Remove a multiresolution image from this item.')
+        .param('itemId', 'The ID of the item.', paramType='path')
     )
 
     @access.public
@@ -112,8 +132,7 @@ class TilesItemResource(Item):
     getTile.cookieAuth = True
     getTile.description = (
         Description('Get an image tile.')
-        .param('itemId', 'The ID of the item, "test", or "clear".',
-               paramType='path')
+        .param('itemId', 'The ID of the item or "test".', paramType='path')
         .param('z', 'The layer number of the tile (0 is the most zoomed-out layer).', paramType='path')
         .param('x', 'The X coordinate of the tile (0 is the left side).', paramType='path')
         .param('y', 'The Y coordinate of the tile (0 is the top).', paramType='path')

--- a/server/rest.py
+++ b/server/rest.py
@@ -76,9 +76,6 @@ class TilesItemResource(Item):
                 raise RestException('"fileId" must be a file on the same item as "itemId".')
 
             item['largeImage'] = largeImageFile['_id']
-        elif largeImageFileId == 'clear':
-            if 'largeImage' in item:
-                del item['largeImage']
         else:
             item['largeImage'] = largeImageFileId
         self.model('item').save(item)

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -70,4 +70,5 @@ class GirderTileSource(TileSource):
             return largeImagePath
 
         except (KeyError, ValidationException, TileSourceException) as e:
-            raise TileSourceException('No large image file in this item: ' % e.message)
+            raise TileSourceException(
+                'No large image file in this item: %s' % e.message)


### PR DESCRIPTION
Also, allow the tiles POST endpoint to accept 'test' to place it in test mode or 'clear' to remove an existing large image flag.